### PR TITLE
The render subcommand was not gathering absolute paths to config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 scratch_templ_dir
 **/templ
 templ
+templ-config-files


### PR DESCRIPTION
therefore after changing directory the config files could not always be found.

This simplifies the process of gathering paths. It enforces that gathering dynamic paths to config files returns an absolute path and defers the chdir until the last moment before command execution